### PR TITLE
Pass this.req/this.res instead of this.request/this.response

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,8 +140,8 @@ module.exports.requestLogger = function (opts) {
 
     var onResponseFinished = function () {
       var responseData = {
-        req: this.request,
-        res: this.response
+        req: this.req,
+        res: this.res
       };
 
       if (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -88,7 +88,7 @@ describe('koaBunyanLogger', function () {
       assert.equal(ringBuffer.records.length, 2);
       assert.ok(record(0).msg.match(REQ_MESSAGE));
       assert.ok(record(1).msg.match(RES_MESSAGE));
-      assert.equal(record(1).res.status, status);
+      assert.equal(record(1).res.statusCode, status);
     }
 
     it('logs requests', function *() {
@@ -185,7 +185,7 @@ describe('koaBunyanLogger', function () {
       assert.ok(record(1).msg.match('clumsy'));
 
       assert.ok(record(2).msg.match(RES_MESSAGE));
-      assert.equal(record(2).res.status, 200);
+      assert.equal(record(2).res.statusCode, 200);
     });
   });
 


### PR DESCRIPTION
Pass this.req/this.res instead of this.request/this.response
    
This make the fields more consistent with other bunyan loggers
and parsers, in particular having res._header have the response
line instead of a header object.
    
NOTE: this changes the format of the res object for request
logging, including res.header and res.status (now res.statusCode)


Reviewer: @aheckmann 