### PR TITLE
Fix req data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 0.11
+- node
 
 script: "make test-travis"
 after_script: "npm install coveralls@2.11.1 && cat ./coverage/lcov.info | coveralls"

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ lint: index.js
 	@ $(LINT) index.js
 
 test: .PHONY
-	@ node --harmony $(MOCHA)
+	@ node $(MOCHA)
 
 test-cov: .PHONY
-	@ node --harmony $(ISTANBUL) cover $(MOCHA)
+	@ node $(ISTANBUL) cover $(MOCHA)
 
 test-travis: lint test-cov
-	@ node --harmony $(ISTANBUL) check-coverage
+	@ node $(ISTANBUL) check-coverage
 
 .PHONY:

--- a/README.md
+++ b/README.md
@@ -297,6 +297,15 @@ app.use(koaBunyanLogger.timeContext({
 }));
 ```
 
+### bunyan export
+
+The internal copy of bunyan is exported as `.bunyan`:
+
+```js
+var koaBunyanLogger = require('koa-bunyan-logger');
+var bunyan = koaBunyanLogger.bunyan;
+```
+
 ## Sponsored by
 
 [Pebble Technology!](https://getpebble.com)

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports.requestIdContext = function (opts) {
  *    - updateRequestLogFields: function (requestData)
  *    - updateResponseLogFields: function (responseData)
  *    - formatRequestMessage: function (requestData)
- *    - formatReponseMessage: function (responseData)
+ *    - formatResponseMessage: function (responseData)
  */
 module.exports.requestLogger = function (opts) {
   opts = opts || {};

--- a/index.js
+++ b/index.js
@@ -257,3 +257,5 @@ module.exports.timeContext = function (opts) {
   }
 };
 
+// Export our copy of bunyan
+module.exports.bunyan = bunyan;

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ module.exports.requestLogger = function (opts) {
     var url = this.url;
 
     var requestData = {
-      req: this.request
+      req: this.req
     };
 
     requestData = updateFields(this, opts.updateLogFields, requestData);

--- a/package.json
+++ b/package.json
@@ -27,17 +27,17 @@
   "author": "Pebble Technology <webteam@getpebble.com>",
   "license": "MIT",
   "dependencies": {
-    "bunyan": "~1.1.3",
+    "bunyan": "~1.5.0",
     "node-uuid": "~1.4.1",
     "on-finished": "~2.1.1"
   },
   "devDependencies": {
-    "co-mocha": "~1.0.3",
-    "co-supertest": "~0.0.7",
-    "istanbul-harmony": "~0.3.0",
+    "co-mocha": "~1.1.2",
+    "co-supertest": "~0.0.10",
+    "istanbul": "~0.4.0",
     "jshint": "~2.5.8",
-    "koa": "~0.13.0",
-    "mocha": "~2.0.1",
-    "supertest": "~0.14.0"
+    "koa": "~1.1.1",
+    "mocha": "~2.3.3",
+    "supertest": "~1.1.0"
   }
 }


### PR DESCRIPTION
Missed this during the last fix -- this.request was being passed for the request logs instead of this.req, which causes problems with custom req serializers and slightly wrong formatting for the standard request logger.

Also, bump bunyan to the latest version, bump test dependencies, and update .travis.yml to test against latest node version.

Reviewer: @aheckmann 